### PR TITLE
fix responsive on blog

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -23,9 +23,7 @@ const { language, frontmatter } = Astro.props
     />
   </head>
   <body class='flex min-h-screen bg-gray-50'>
-    <div
-      class='flex flex-col py-12 md:p-12 flex-1 max-w-96 md:max-w-5xl mx-auto'
-    >
+    <div class='flex flex-col p-12 flex-1 max-w-5xl mx-auto'>
       <Navbar />
       <div class='flex flex-col md:flex-row gap-4 py-4'>
         <div


### PR DESCRIPTION
Vi tu artículo sobre "Despliegues a VPS listos para producción" en x en mobile y al abrirlo vi que el navbar desbordaba la página y tenía un margen a la derecha vacío. 

<img src="https://github.com/user-attachments/assets/a1ae4a8d-5fae-4d88-94c0-d5d7823d8a85" width="200">

He modificado el div que equivale al main content para que tenga las mismas clases que la home que sí se veía bien en mobile.