### PR TITLE
Fix font loading flash (FOUC)

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -14,6 +14,13 @@ const { title, language } = Astro.props
     />
     <meta name='viewport' content='width=device-width' />
     <meta name='generator' content={Astro.generator} />
+    <link
+      rel='preload'
+      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      as='font'
+      type='font/woff2'
+      crossorigin
+    />
     <title>{title}</title>
   </head>
   <body class='flex flex-col bg-[#FDFDFC] text-[#1b1b18]'>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -17,6 +17,13 @@ const { language, frontmatter } = Astro.props
     />
     <meta name='viewport' content='width=device-width' />
     <meta name='generator' content={Astro.generator} />
+    <link
+      rel='preload'
+      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      as='font'
+      type='font/woff2'
+      crossorigin
+    />
     <Head
       title={frontmatter.title}
       description={frontmatter.description}


### PR DESCRIPTION
## Summary
- Adds `<link rel="preload">` tags for the Aleo Variable font in both MainLayout.astro and PostLayout.astro
- Ensures fonts are downloaded early in the page load process, before first paint
- Eliminates the flash of unstyled content (FOUC) that occurred when fonts loaded asynchronously

## Changes
- Modified `src/layouts/MainLayout.astro` to include font preload link
- Modified `src/layouts/PostLayout.astro` to include font preload link

## Technical Details
The font was previously loaded via JavaScript import (`import '@fontsource-variable/aleo'`), causing it to load asynchronously after initial render. By adding preload hints in the HTML head, the browser fetches the font files earlier, preventing the flash when the actual font loads.

## Test plan
- [ ] Build the project and verify no errors
- [ ] Test on a fresh browser session (clear cache) to observe font loading behavior
- [ ] Verify there's no flash when navigating to pages using MainLayout
- [ ] Verify there's no flash when viewing blog posts using PostLayout

🤖 Generated with [Claude Code](https://claude.com/claude-code)