### PR TITLE
Fix font preload URL to use correct build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Astro Starter Kit: Minimal
 
-```sh
-npm create astro@latest -- --template minimal
-```
-
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -14,6 +14,13 @@ const { title, language } = Astro.props
     />
     <meta name='viewport' content='width=device-width' />
     <meta name='generator' content={Astro.generator} />
+    <link
+      rel='preload'
+      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      as='font'
+      type='font/woff2'
+      crossorigin
+    />
     <title>{title}</title>
   </head>
   <body class='flex flex-col bg-[#FDFDFC] text-[#1b1b18]'>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -2,6 +2,7 @@
 import '@fontsource-variable/aleo'
 import Navbar from './Navbar.astro'
 import Footer from './Footer.astro'
+import aleoFont from '@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2?url'
 const { title, language } = Astro.props
 ---
 
@@ -16,7 +17,7 @@ const { title, language } = Astro.props
     <meta name='generator' content={Astro.generator} />
     <link
       rel='preload'
-      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      href={aleoFont}
       as='font'
       type='font/woff2'
       crossorigin

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -5,6 +5,7 @@ import Head from '../components/Head.astro'
 import Footer from './Footer.astro'
 import Navbar from './Navbar.astro'
 import ProgressBar from '../components/ProgressBar.astro'
+import aleoFont from '@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2?url'
 const { language, frontmatter } = Astro.props
 ---
 
@@ -19,7 +20,7 @@ const { language, frontmatter } = Astro.props
     <meta name='generator' content={Astro.generator} />
     <link
       rel='preload'
-      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      href={aleoFont}
       as='font'
       type='font/woff2'
       crossorigin

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -17,6 +17,13 @@ const { language, frontmatter } = Astro.props
     />
     <meta name='viewport' content='width=device-width' />
     <meta name='generator' content={Astro.generator} />
+    <link
+      rel='preload'
+      href='/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2'
+      as='font'
+      type='font/woff2'
+      crossorigin
+    />
     <Head
       title={frontmatter.title}
       description={frontmatter.description}


### PR DESCRIPTION
## Summary
This PR fixes the font preload implementation from PR #4. The previous implementation used a hardcoded path to `node_modules` which doesn't exist in the built output.

## Changes
- Import the font file directly using Vite's `?url` syntax to get the processed URL with correct hash
- Update both `MainLayout.astro` and `PostLayout.astro` to use the imported font URL
- The preload link now correctly points to `/_astro/aleo-latin-wght-normal.[hash].woff2`

## Technical Details
The previous implementation used:
```html
<link rel="preload" href="/node_modules/@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2" />
```

This path doesn't exist in production because Astro/Vite processes the font files and outputs them to the `_astro` directory with hashed filenames.

The fix imports the font file directly:
```js
import aleoFont from '@fontsource-variable/aleo/files/aleo-latin-wght-normal.woff2?url'
```

This gives us the correct processed URL that works in both development and production.

## Test Results
- ✅ Build completes successfully
- ✅ Preload links correctly generated in HTML: `/_astro/aleo-latin-wght-normal.BrlYyHnC.woff2`
- ✅ Font files exist in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)